### PR TITLE
Don't caclulate swap if none exists

### DIFF
--- a/usr/local/sbin/easyengine
+++ b/usr/local/sbin/easyengine
@@ -813,7 +813,7 @@ EE_SYSTEM_STATUS()
 	if [[ $SWAP_TOTAL > 0 ]]
 	then
 		SWAP_USED=$(free | grep Swap: | awk '{print $3}')
-		SWAP_USAGE=$(echo "$SWAP_USED*100/$SWAP_TOTAL" | bc -l | cut -d'.' -f1 && echo "%")
+		SWAP_USAGE=$(echo "$SWAP_USED*100/$SWAP_TOTAL" | bc -l | cut -d'.' -f1)%
 	else
 		SWAP_USAGE=$(echo "N/A")
 	fi


### PR DESCRIPTION
Systems without an active swap report 0/0% utilization which causes an error to be displayed when executing the `ee system status` command. 

Added a conditional to check for no-swap and the status screen now displays 'N/A' instead of 0%...

![screen shot 2014-05-04 at 3 10 32 pm](https://cloud.githubusercontent.com/assets/1479206/2873808/d46474ca-d3bf-11e3-82e1-9aa519549838.png)
