### PR TITLE
Allow deleting site without prompt

### DIFF
--- a/usr/local/sbin/easyengine
+++ b/usr/local/sbin/easyengine
@@ -1577,7 +1577,7 @@ REMOVEFILES()
 		ANSWER="y"
 	else
 		# Ask user for confirmation
-		read -p "Are You Sure To Drop $WPDBNAME Database (y/n): " ANSWER
+		read -p "Are You Sure To Remove $DOMAIN Webroot (y/n): " ANSWER
 	fi
 
 	if [ "$ANSWER" = "y" ]
@@ -1601,7 +1601,7 @@ REMOVENGINXCONF()
 		ANSWER="y"
 	else
 		# Ask user for confirmation
-		read -p "Are You Sure To Drop $WPDBNAME Database (y/n): " ANSWER
+		read -p "Are You Sure To Remove $DOMAIN Nginx Configuration (y/n): " ANSWER
 	fi
 	if [ "$ANSWER" = "y" ]
 	then


### PR DESCRIPTION
ee site delete example.com --all-no-prompt
Removes db, files and nginx config without asking user. 
Useful to remove interactivity when calling from a remote server.

I've been working on a tool to mange multiple servers runing ee from one central place, but the required user interactivity in the scripts doesn't play very nice when calling remotely. You'd have to use something like pexpect quite a few times to get through the script which slows the whole process down a lot.

Therefore I propose to add options to bypass the prompts.
