### PR TITLE
Support for Akismet

### DIFF
--- a/config/nginx/common/wpcommon.conf
+++ b/config/nginx/common/wpcommon.conf
@@ -38,3 +38,13 @@ location ~ ([^/]*)sitemap(.*)\.x(m|s)l$ {
 
 	access_log off;
 }
+
+
+# Akismet
+location /wp-content/plugins/akismet/ {
+        location ~ \.php$ {
+                allow 127.0.0.1;
+                deny all;
+        }
+}
+


### PR DESCRIPTION
Replaces the directives found in the .htaccess file inside Akismet plugin.

Based on: https://www.tinywp.in/akismet-nginx-rewrite-rules/
