### PR TITLE
Added php tags on ee-config.php for --mysql install

### DIFF
--- a/bin/easyengine
+++ b/bin/easyengine
@@ -425,7 +425,7 @@ elif [ "$EE_FIRST" = "site" ]; then
 				ee_mod_setup_database
 
 				# Add Database Information On ee-config.php
-				echo -e "define('DB_NAME', '$EE_DB_NAME'); \ndefine('DB_USER', '$EE_DB_USER'); \ndefine('DB_PASSWORD', '$EE_DB_PASS'); \ndefine('DB_HOST', '$EE_MYSQL_HOST');" \
+				echo -e "<?php /ndefine('DB_NAME', '$EE_DB_NAME'); \ndefine('DB_USER', '$EE_DB_USER'); \ndefine('DB_PASSWORD', '$EE_DB_PASS'); \ndefine('DB_HOST', '$EE_MYSQL_HOST'); /n?>" \
 				&>> /var/www/$EE_DOMAIN/ee-config.php
 			fi
 


### PR DESCRIPTION
Currently, if you use the ee-config.php file with include() or require(), it simply echos the file (with full creds!) to the requested page. By encapsulating them within <?php ?> tags, it enables the ability to simply reference the defined variables.
