### PR TITLE
Cache only certain response codes

### DIFF
--- a/config/nginx/conf.d/fastcgi.conf
+++ b/config/nginx/conf.d/fastcgi.conf
@@ -3,7 +3,7 @@
 fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:50m inactive=60m;
 fastcgi_cache_key "$scheme$request_method$host$request_uri";
 fastcgi_cache_use_stale error timeout invalid_header updating http_500 http_503;
-fastcgi_cache_valid 200 1h;
+fastcgi_cache_valid 200 301 302 404 1h;
 
 fastcgi_buffers 16 16k;
 fastcgi_buffer_size 32k;

--- a/config/nginx/conf.d/fastcgi.conf
+++ b/config/nginx/conf.d/fastcgi.conf
@@ -3,7 +3,7 @@
 fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:50m inactive=60m;
 fastcgi_cache_key "$scheme$request_method$host$request_uri";
 fastcgi_cache_use_stale error timeout invalid_header updating http_500 http_503;
-fastcgi_cache_valid any 1h;
+fastcgi_cache_valid 200 1h;
 
 fastcgi_buffers 16 16k;
 fastcgi_buffer_size 32k;


### PR DESCRIPTION
fastcgi cache should only cache pages with certain http response codes instead of "any" which can sometimes cache transient 5XX error pages. this patch changes the caching behavior so that it only caches 200, 301, 302, and 404.

see http://community.rtcamp.com/t/fascgi-cache-caching-error-pages/3847