### PR TITLE
fix(deps): upgrade composer/composer to 2.2.28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.0",
-        "composer/composer": "2.2.26",
+        "composer/composer": "2.2.28",
         "composer/semver": "3.2.4",
         "daverandom/libdns": "^2.0",
         "easyengine/admin-tools-command": "v1.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "879de756bedc890b7ccdef7793913d0a",
+    "content-hash": "e287f56534287e5bd948752cf6ce179c",
     "packages": [
         {
             "name": "acmephp/core",
@@ -271,16 +271,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.2.26",
+            "version": "2.2.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "c6ad1d795efbea3f15805c5e5a86c5a60ba3ed87"
+                "reference": "5104b27aaa735dcbadc1bd65f5ff1ef3552c543a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/c6ad1d795efbea3f15805c5e5a86c5a60ba3ed87",
-                "reference": "c6ad1d795efbea3f15805c5e5a86c5a60ba3ed87",
+                "url": "https://api.github.com/repos/composer/composer/zipball/5104b27aaa735dcbadc1bd65f5ff1ef3552c543a",
+                "reference": "5104b27aaa735dcbadc1bd65f5ff1ef3552c543a",
                 "shasum": ""
             },
             "require": {
@@ -350,7 +350,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.2.26"
+                "source": "https://github.com/composer/composer/tree/2.2.28"
             },
             "funding": [
                 {
@@ -362,7 +362,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-30T12:39:48+00:00"
+            "time": "2026-05-13T07:28:55+00:00"
         },
         {
             "name": "composer/metadata-minifier",


### PR DESCRIPTION
## Problem

The scheduled CI build (`Build 🔨 + Test 👨‍🔧`) has been failing daily since at least 2026-05-28. `composer/composer 2.2.26` (pinned exactly in `composer.json`) is flagged by three security advisories:

- `PKSA-pwvr-3754-v57r`
- `PKSA-t5r2-p5q9-mtpn`
- `PKSA-6bp1-9hfj-2cgv`

Composer's security advisory blocking policy prevents the package from being installed, causing `composer update` to exit with code 2.

## Fix

Bumps `composer/composer` from `2.2.26` → `2.2.28` (latest in the LTS 2.2.x line). Version 2.2.28 has no blocking security advisories and retains the same PHP `^5.3.2 || ^7.0 || ^8.0` requirement, so it's fully compatible with this project's `>=7.0` constraint.

## Test plan

- [ ] CI `Build Phar` job completes without the dependency resolution error