### PR TITLE
chore(composer): update site-command to v3.7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "easyengine/mailhog-command": "v1.0.3",
         "easyengine/service-command": "v1.6.2",
         "easyengine/shell-command": "v1.1.3",
-        "easyengine/site-command": "v3.7.4",
+        "easyengine/site-command": "v3.7.5",
         "easyengine/site-type-php": "v1.10.0",
         "easyengine/site-type-wp": "v1.10.0",
         "monolog/monolog": "1.24.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84eb3b2a41b3b81c38ab7021d6885ce1",
+    "content-hash": "01d7ab9a5307343e115767f5962b038b",
     "packages": [
         {
             "name": "acmephp/core",
@@ -1196,16 +1196,16 @@
         },
         {
             "name": "easyengine/site-command",
-            "version": "v3.7.4",
+            "version": "v3.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/EasyEngine/site-command.git",
-                "reference": "b8c611bac5e659680324d1a78b69a82b95357c58"
+                "reference": "70a0854141ad454e1b9c35bdc4412cb1154c9961"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/EasyEngine/site-command/zipball/b8c611bac5e659680324d1a78b69a82b95357c58",
-                "reference": "b8c611bac5e659680324d1a78b69a82b95357c58",
+                "url": "https://api.github.com/repos/EasyEngine/site-command/zipball/70a0854141ad454e1b9c35bdc4412cb1154c9961",
+                "reference": "70a0854141ad454e1b9c35bdc4412cb1154c9961",
                 "shasum": ""
             },
             "require": {
@@ -1267,9 +1267,9 @@
             "homepage": "https://github.com/easyengine/site-command",
             "support": {
                 "issues": "https://github.com/EasyEngine/site-command/issues",
-                "source": "https://github.com/EasyEngine/site-command/tree/v3.7.4"
+                "source": "https://github.com/EasyEngine/site-command/tree/v3.7.5"
             },
-            "time": "2026-06-11T10:20:20+00:00"
+            "time": "2026-06-12T05:57:45+00:00"
         },
         {
             "name": "easyengine/site-type-php",


### PR DESCRIPTION
## Summary

Bumps `easyengine/site-command` from `v3.7.4` → `v3.7.5`.

### Changes in v3.7.5 ([EasyEngine/site-command](https://github.com/EasyEngine/site-command))

* fix(backup): support older rclone on restore and add a backup --list preflight https://github.com/EasyEngine/site-command/pull/478