### PR TITLE
chore(composer): update site-command to v3.7.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "easyengine/mailhog-command": "v1.0.3",
         "easyengine/service-command": "v1.6.2",
         "easyengine/shell-command": "v1.1.3",
-        "easyengine/site-command": "v3.7.5",
+        "easyengine/site-command": "v3.7.6",
         "easyengine/site-type-php": "v1.10.0",
         "easyengine/site-type-wp": "v1.10.0",
         "monolog/monolog": "1.24.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01d7ab9a5307343e115767f5962b038b",
+    "content-hash": "1755b77d9962f016064b2be62147eb4e",
     "packages": [
         {
             "name": "acmephp/core",
@@ -1196,16 +1196,16 @@
         },
         {
             "name": "easyengine/site-command",
-            "version": "v3.7.5",
+            "version": "v3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/EasyEngine/site-command.git",
-                "reference": "70a0854141ad454e1b9c35bdc4412cb1154c9961"
+                "reference": "25d42db871784a942fc140a7483633180b6b6943"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/EasyEngine/site-command/zipball/70a0854141ad454e1b9c35bdc4412cb1154c9961",
-                "reference": "70a0854141ad454e1b9c35bdc4412cb1154c9961",
+                "url": "https://api.github.com/repos/EasyEngine/site-command/zipball/25d42db871784a942fc140a7483633180b6b6943",
+                "reference": "25d42db871784a942fc140a7483633180b6b6943",
                 "shasum": ""
             },
             "require": {
@@ -1267,9 +1267,9 @@
             "homepage": "https://github.com/easyengine/site-command",
             "support": {
                 "issues": "https://github.com/EasyEngine/site-command/issues",
-                "source": "https://github.com/EasyEngine/site-command/tree/v3.7.5"
+                "source": "https://github.com/EasyEngine/site-command/tree/v3.7.6"
             },
-            "time": "2026-06-12T05:57:45+00:00"
+            "time": "2026-06-12T11:49:47+00:00"
         },
         {
             "name": "easyengine/site-type-php",


### PR DESCRIPTION
## Summary

Bumps `easyengine/site-command` from `v3.7.5` → `v3.7.6`.

### Changes in v3.7.6 ([EasyEngine/site-command](https://github.com/EasyEngine/site-command))

* fix(restore): raise PHP memory_limit for wp core download to prevent OOM https://github.com/EasyEngine/site-command/pull/479