### PR TITLE
feat(cli): configure logrotate during migration

### DIFF
--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -147,10 +147,27 @@ class Utils {
 			return true;
 		}
 
-		$message = trim( $result->stdout ?: $result->stderr );
+		$message = trim( $result->stdout );
+
+		if ( ! self::has_validation_error( $message ) ) {
+			\EE::debug( 'EasyEngine logrotate validation returned a non-zero exit code without errors.' . ( $message ? ' ' . $message : '' ) );
+			return true;
+		}
+
 		\EE::warning( 'Unable to validate EasyEngine logrotate configs.' . ( $message ? ' ' . $message : '' ) );
 
 		return false;
+	}
+
+	/**
+	 * Check whether logrotate dry-run output contains a real validation error.
+	 *
+	 * @param string $output Dry-run output.
+	 * @return bool
+	 */
+	private static function has_validation_error( $output ) {
+
+		return (bool) preg_match( '/(^|\n)\s*(error:|syntax error|bad |unknown |unexpected |duplicate log entry|.*not found|.*permission denied)/i', $output );
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -139,8 +139,10 @@ class Utils {
 	 */
 	private static function is_legacy_config( $contents ) {
 
-		return false !== strpos( $contents, '/opt/easyengine/sites/' )
-			|| false !== strpos( $contents, '/opt/easyengine/services/nginx-proxy/logs/*.log' );
+		$root_dir = rtrim( EE_ROOT_DIR, '/' );
+
+		return false !== strpos( $contents, $root_dir . '/sites/' )
+			|| false !== strpos( $contents, $root_dir . '/services/nginx-proxy/logs/*.log' );
 	}
 
 	/**
@@ -150,9 +152,11 @@ class Utils {
 	 */
 	private static function get_sites_config() {
 
-		return <<<'LOGROTATE'
-/opt/easyengine/sites/*/logs/nginx/*.log
-/opt/easyengine/sites/*/logs/php/*.log {
+		$root_dir = rtrim( EE_ROOT_DIR, '/' );
+
+		return <<<LOGROTATE
+{$root_dir}/sites/*/logs/nginx/*.log
+{$root_dir}/sites/*/logs/php/*.log {
     daily
     missingok
     rotate 30
@@ -174,8 +178,10 @@ LOGROTATE
 	 */
 	private static function get_nginx_proxy_config() {
 
-		return <<<'LOGROTATE'
-/opt/easyengine/services/nginx-proxy/logs/*.log {
+		$root_dir = rtrim( EE_ROOT_DIR, '/' );
+
+		return <<<LOGROTATE
+{$root_dir}/services/nginx-proxy/logs/*.log {
     daily
     missingok
     rotate 30

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -152,28 +152,11 @@ class Utils {
 			}
 
 			$message = trim( $result->stdout );
-
-			if ( ! self::has_validation_error( $message ) ) {
-				\EE::debug( 'EasyEngine logrotate validation returned a non-zero exit code without errors for ' . $file . ( $message ? '. ' . $message : '' ) );
-				continue;
-			}
-
 			\EE::warning( 'Unable to validate EasyEngine logrotate config: ' . $file . ( $message ? '. ' . $message : '' ) );
 			$is_valid = false;
 		}
 
 		return $is_valid;
-	}
-
-	/**
-	 * Check whether logrotate dry-run output contains a real validation error.
-	 *
-	 * @param string $output Dry-run output.
-	 * @return bool
-	 */
-	private static function has_validation_error( $output ) {
-
-		return (bool) preg_match( '/(^|\n)\s*(error:|syntax error|bad |unknown |unexpected |duplicate log entry|.*not found|.*permission denied)/i', $output );
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -47,7 +47,7 @@ class Utils {
 		$sites_written  = self::write_config( self::SITES_CONFIG_FILE, self::get_sites_config() );
 		$proxy_written  = self::write_config( self::NGINX_PROXY_CONFIG_FILE, self::get_nginx_proxy_config() );
 
-		if ( $ee_log_written && $sites_written && $proxy_written ) {
+		if ( $ee_log_written && $sites_written && $proxy_written && self::validate_configs( self::get_config_files() ) ) {
 			self::cleanup_legacy_configs();
 		}
 	}
@@ -114,6 +114,46 @@ class Utils {
 		\EE::debug( 'EasyEngine logrotate config written: ' . $file );
 
 		return true;
+	}
+
+	/**
+	 * Validate generated logrotate configs.
+	 *
+	 * @param array $files Config files.
+	 * @return bool
+	 */
+	private static function validate_configs( array $files ) {
+
+		$is_valid = true;
+
+		foreach ( $files as $file ) {
+			$result = \EE::launch( 'logrotate -d ' . escapeshellarg( $file ), false, true );
+
+			if ( 0 === $result->return_code ) {
+				\EE::debug( 'EasyEngine logrotate config validated: ' . $file );
+				continue;
+			}
+
+			$message = trim( $result->stderr ?: $result->stdout );
+			\EE::warning( 'Unable to validate EasyEngine logrotate config: ' . $file . ( $message ? '. ' . $message : '' ) );
+			$is_valid = false;
+		}
+
+		return $is_valid;
+	}
+
+	/**
+	 * Return generated EasyEngine logrotate config files.
+	 *
+	 * @return array
+	 */
+	private static function get_config_files() {
+
+		return [
+			self::EE_LOG_CONFIG_FILE,
+			self::SITES_CONFIG_FILE,
+			self::NGINX_PROXY_CONFIG_FILE,
+		];
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -109,6 +109,7 @@ class Utils {
 		}
 
 		@chmod( $file, 0644 );
+		\EE::debug( 'EasyEngine logrotate config written: ' . $file );
 
 		return true;
 	}
@@ -137,7 +138,9 @@ class Utils {
 				continue;
 			}
 
-			if ( ! @unlink( $file ) ) {
+			if ( @unlink( $file ) ) {
+				\EE::debug( 'Removed legacy EasyEngine logrotate config: ' . $file );
+			} else {
 				\EE::warning( 'Unable to remove legacy EasyEngine logrotate config: ' . $file );
 			}
 		}

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -51,6 +51,7 @@ class Utils {
 
 		if ( $ee_log_written && $sites_written && $proxy_written && self::validate_configs( self::get_config_files() ) ) {
 			self::cleanup_legacy_configs();
+			self::force_rotate_configs( self::get_config_files() );
 		}
 	}
 
@@ -168,6 +169,28 @@ class Utils {
 	private static function has_validation_error( $output ) {
 
 		return (bool) preg_match( '/(^|\n)\s*(error:|syntax error|bad |unknown |unexpected |duplicate log entry|.*not found|.*permission denied)/i', $output );
+	}
+
+	/**
+	 * Force rotate EasyEngine logs once after setup or update.
+	 *
+	 * @param array $files Config files.
+	 * @return bool
+	 */
+	private static function force_rotate_configs( array $files ) {
+
+		$command = 'logrotate -f ' . implode( ' ', array_map( 'escapeshellarg', $files ) ) . ' 2>&1';
+		$result  = \EE::launch( $command, false, true );
+
+		if ( 0 === $result->return_code ) {
+			\EE::debug( 'EasyEngine logs force rotated.' );
+			return true;
+		}
+
+		$message = trim( $result->stdout );
+		\EE::warning( 'Unable to force rotate EasyEngine logs.' . ( $message ? ' ' . $message : '' ) );
+
+		return false;
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -38,9 +38,11 @@ class Utils {
 			return;
 		}
 
-		if ( ! is_dir( self::CONFIG_DIR ) && ! @mkdir( self::CONFIG_DIR, 0755, true ) ) {
-			\EE::warning( 'Unable to create logrotate config directory: ' . self::CONFIG_DIR );
-			return;
+		if ( ! is_dir( self::CONFIG_DIR ) ) {
+			if ( ! is_writable( dirname( self::CONFIG_DIR ) ) || ! mkdir( self::CONFIG_DIR, 0755, true ) ) {
+				\EE::warning( 'Unable to create logrotate config directory: ' . self::CONFIG_DIR );
+				return;
+			}
 		}
 
 		$ee_log_written = self::write_config( self::EE_LOG_CONFIG_FILE, self::get_ee_log_config() );
@@ -101,16 +103,29 @@ class Utils {
 	 */
 	private static function write_config( $file, $content ) {
 
-		if ( file_exists( $file ) && $content === @file_get_contents( $file ) ) {
+		if ( file_exists( $file ) && is_readable( $file ) && $content === file_get_contents( $file ) ) {
 			return true;
 		}
 
-		if ( false === @file_put_contents( $file, $content ) ) {
+		if ( file_exists( $file ) && ! is_writable( $file ) ) {
+			\EE::warning( 'EasyEngine logrotate config is not writable: ' . $file );
+			return false;
+		}
+
+		if ( ! file_exists( $file ) && ! is_writable( dirname( $file ) ) ) {
+			\EE::warning( 'EasyEngine logrotate config directory is not writable: ' . dirname( $file ) );
+			return false;
+		}
+
+		if ( false === file_put_contents( $file, $content ) ) {
 			\EE::warning( 'Unable to write EasyEngine logrotate config: ' . $file );
 			return false;
 		}
 
-		@chmod( $file, 0644 );
+		if ( ! chmod( $file, 0644 ) ) {
+			\EE::warning( 'Unable to set permissions on EasyEngine logrotate config: ' . $file );
+		}
+
 		\EE::debug( 'EasyEngine logrotate config written: ' . $file );
 
 		return true;
@@ -170,13 +185,22 @@ class Utils {
 				continue;
 			}
 
-			$contents = @file_get_contents( $file );
+			if ( ! is_readable( $file ) ) {
+				continue;
+			}
+
+			$contents = file_get_contents( $file );
 
 			if ( false === $contents || ! self::is_legacy_config( $basename, $contents ) ) {
 				continue;
 			}
 
-			if ( @unlink( $file ) ) {
+			if ( ! is_writable( dirname( $file ) ) ) {
+				\EE::warning( 'Unable to remove legacy EasyEngine logrotate config, directory is not writable: ' . $file );
+				continue;
+			}
+
+			if ( unlink( $file ) ) {
 				\EE::debug( 'Removed legacy EasyEngine logrotate config: ' . $file );
 			} else {
 				\EE::warning( 'Unable to remove legacy EasyEngine logrotate config: ' . $file );

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -245,7 +245,6 @@ class Utils {
     delaycompress
     notifempty
     copytruncate
-    create 0640 www-data adm
     sharedscripts
 }
 LOGROTATE
@@ -270,7 +269,6 @@ LOGROTATE
     delaycompress
     notifempty
     copytruncate
-    create 0640 www-data adm
     sharedscripts
 }
 LOGROTATE

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -245,8 +245,10 @@ class Utils {
 				continue;
 			}
 
-			if ( ! is_writable( dirname( $file ) ) ) {
-				\EE::warning( 'Unable to remove legacy EasyEngine logrotate config, directory is not writable: ' . $file );
+			$directory = dirname( $file );
+
+			if ( ! is_writable( $directory ) ) {
+				\EE::warning( 'Unable to remove legacy EasyEngine logrotate config, directory is not writable: ' . $directory );
 				continue;
 			}
 

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace EE\Logrotate;
+
+/**
+ * Logrotate setup utilities.
+ */
+class Utils {
+
+	const CONFIG_DIR = '/etc/logrotate.d';
+	const SITES_CONFIG_FILE = '/etc/logrotate.d/ee_sites';
+	const NGINX_PROXY_CONFIG_FILE = '/etc/logrotate.d/ee_nginx_proxy';
+
+	/**
+	 * Configure logrotate for EasyEngine site and nginx-proxy logs.
+	 */
+	public static function setup_logrotate() {
+
+		if ( defined( 'IS_DARWIN' ) && IS_DARWIN ) {
+			\EE::debug( 'Skipping logrotate setup on macOS.' );
+			return;
+		}
+
+		if ( ! self::ensure_logrotate_installed() ) {
+			return;
+		}
+
+		if ( ! is_dir( self::CONFIG_DIR ) && ! @mkdir( self::CONFIG_DIR, 0755, true ) ) {
+			\EE::warning( 'Unable to create logrotate config directory: ' . self::CONFIG_DIR );
+			return;
+		}
+
+		$sites_written = self::write_config( self::SITES_CONFIG_FILE, self::get_sites_config() );
+		$proxy_written = self::write_config( self::NGINX_PROXY_CONFIG_FILE, self::get_nginx_proxy_config() );
+
+		if ( $sites_written && $proxy_written ) {
+			self::cleanup_legacy_configs();
+		}
+	}
+
+	/**
+	 * Ensure logrotate is available on supported systems.
+	 *
+	 * @return bool
+	 */
+	private static function ensure_logrotate_installed() {
+
+		if ( self::command_exists( 'logrotate' ) ) {
+			return true;
+		}
+
+		if ( ! self::command_exists( 'apt-get' ) ) {
+			\EE::warning( 'logrotate is not installed and apt-get is unavailable. Skipping EasyEngine logrotate setup.' );
+			return false;
+		}
+
+		\EE::log( 'Installing logrotate.' );
+		$result = \EE::launch( 'DEBIAN_FRONTEND=noninteractive apt-get install -y logrotate', false, true );
+
+		if ( 0 !== $result->return_code || ! self::command_exists( 'logrotate' ) ) {
+			\EE::warning( 'Unable to install logrotate. Skipping EasyEngine logrotate setup.' );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a command is available in PATH.
+	 *
+	 * @param string $command Command name.
+	 * @return bool
+	 */
+	private static function command_exists( $command ) {
+
+		$result = \EE::launch( 'command -v ' . escapeshellarg( $command ) . ' >/dev/null 2>&1', false, true );
+
+		return 0 === $result->return_code;
+	}
+
+	/**
+	 * Write a logrotate config if it is missing or stale.
+	 *
+	 * @param string $file Config file path.
+	 * @param string $content Config content.
+	 * @return bool
+	 */
+	private static function write_config( $file, $content ) {
+
+		if ( file_exists( $file ) && $content === @file_get_contents( $file ) ) {
+			return true;
+		}
+
+		if ( false === @file_put_contents( $file, $content ) ) {
+			\EE::warning( 'Unable to write EasyEngine logrotate config: ' . $file );
+			return false;
+		}
+
+		@chmod( $file, 0644 );
+
+		return true;
+	}
+
+	/**
+	 * Remove old per-site/proxy configs that duplicate the wildcard configs.
+	 */
+	private static function cleanup_legacy_configs() {
+
+		$files = glob( self::CONFIG_DIR . '/ee_*' );
+
+		if ( false === $files ) {
+			return;
+		}
+
+		foreach ( $files as $file ) {
+			$basename = basename( $file );
+
+			if ( in_array( $basename, [ 'ee_sites', 'ee_nginx_proxy' ], true ) || ! is_file( $file ) ) {
+				continue;
+			}
+
+			$contents = @file_get_contents( $file );
+
+			if ( false === $contents || ! self::is_legacy_config( $contents ) ) {
+				continue;
+			}
+
+			if ( ! @unlink( $file ) ) {
+				\EE::warning( 'Unable to remove legacy EasyEngine logrotate config: ' . $file );
+			}
+		}
+	}
+
+	/**
+	 * Check whether a config duplicates EasyEngine log rotation.
+	 *
+	 * @param string $contents Config contents.
+	 * @return bool
+	 */
+	private static function is_legacy_config( $contents ) {
+
+		return false !== strpos( $contents, '/opt/easyengine/sites/' )
+			|| false !== strpos( $contents, '/opt/easyengine/services/nginx-proxy/logs/*.log' );
+	}
+
+	/**
+	 * Return the site logs config.
+	 *
+	 * @return string
+	 */
+	private static function get_sites_config() {
+
+		return <<<'LOGROTATE'
+/opt/easyengine/sites/*/logs/nginx/*.log
+/opt/easyengine/sites/*/logs/php/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    create 0640 www-data adm
+    sharedscripts
+}
+LOGROTATE
+		. PHP_EOL;
+	}
+
+	/**
+	 * Return the nginx-proxy logs config.
+	 *
+	 * @return string
+	 */
+	private static function get_nginx_proxy_config() {
+
+		return <<<'LOGROTATE'
+/opt/easyengine/services/nginx-proxy/logs/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    create 0640 www-data adm
+    sharedscripts
+}
+LOGROTATE
+		. PHP_EOL;
+	}
+}

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -124,22 +124,18 @@ class Utils {
 	 */
 	private static function validate_configs( array $files ) {
 
-		$is_valid = true;
+		$command = 'logrotate -d ' . implode( ' ', array_map( 'escapeshellarg', $files ) ) . ' 2>&1';
+		$result  = \EE::launch( $command, false, true );
 
-		foreach ( $files as $file ) {
-			$result = \EE::launch( 'logrotate -d ' . escapeshellarg( $file ), false, true );
-
-			if ( 0 === $result->return_code ) {
-				\EE::debug( 'EasyEngine logrotate config validated: ' . $file );
-				continue;
-			}
-
-			$message = trim( $result->stderr ?: $result->stdout );
-			\EE::warning( 'Unable to validate EasyEngine logrotate config: ' . $file . ( $message ? '. ' . $message : '' ) );
-			$is_valid = false;
+		if ( 0 === $result->return_code ) {
+			\EE::debug( 'EasyEngine logrotate configs validated.' );
+			return true;
 		}
 
-		return $is_valid;
+		$message = trim( $result->stdout ?: $result->stderr );
+		\EE::warning( 'Unable to validate EasyEngine logrotate configs.' . ( $message ? ' ' . $message : '' ) );
+
+		return false;
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -16,6 +16,18 @@ class Utils {
 	 */
 	public static function setup_logrotate() {
 
+		try {
+			self::setup_logrotate_config();
+		} catch ( \Throwable $e ) {
+			\EE::warning( 'Unable to setup EasyEngine logrotate config: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Configure logrotate for EasyEngine site and nginx-proxy logs.
+	 */
+	private static function setup_logrotate_config() {
+
 		if ( defined( 'IS_DARWIN' ) && IS_DARWIN ) {
 			\EE::debug( 'Skipping logrotate setup on macOS.' );
 			return;

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -13,7 +13,7 @@ class Utils {
 	const NGINX_PROXY_CONFIG_FILE = '/etc/logrotate.d/ee_nginx_proxy';
 
 	/**
-	 * Configure logrotate for EasyEngine site and nginx-proxy logs.
+	 * Configure logrotate for EasyEngine CLI, site, and nginx-proxy logs.
 	 */
 	public static function setup_logrotate() {
 
@@ -25,7 +25,7 @@ class Utils {
 	}
 
 	/**
-	 * Configure logrotate for EasyEngine site and nginx-proxy logs.
+	 * Configure logrotate for EasyEngine CLI, site, and nginx-proxy logs.
 	 */
 	private static function setup_logrotate_config() {
 

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -8,6 +8,7 @@ namespace EE\Logrotate;
 class Utils {
 
 	const CONFIG_DIR = '/etc/logrotate.d';
+	const EE_LOG_CONFIG_FILE = '/etc/logrotate.d/ee_cli';
 	const SITES_CONFIG_FILE = '/etc/logrotate.d/ee_sites';
 	const NGINX_PROXY_CONFIG_FILE = '/etc/logrotate.d/ee_nginx_proxy';
 
@@ -42,10 +43,11 @@ class Utils {
 			return;
 		}
 
-		$sites_written = self::write_config( self::SITES_CONFIG_FILE, self::get_sites_config() );
-		$proxy_written = self::write_config( self::NGINX_PROXY_CONFIG_FILE, self::get_nginx_proxy_config() );
+		$ee_log_written = self::write_config( self::EE_LOG_CONFIG_FILE, self::get_ee_log_config() );
+		$sites_written  = self::write_config( self::SITES_CONFIG_FILE, self::get_sites_config() );
+		$proxy_written  = self::write_config( self::NGINX_PROXY_CONFIG_FILE, self::get_nginx_proxy_config() );
 
-		if ( $sites_written && $proxy_written ) {
+		if ( $ee_log_written && $sites_written && $proxy_written ) {
 			self::cleanup_legacy_configs();
 		}
 	}
@@ -128,7 +130,7 @@ class Utils {
 		foreach ( $files as $file ) {
 			$basename = basename( $file );
 
-			if ( in_array( $basename, [ 'ee_sites', 'ee_nginx_proxy' ], true ) || ! is_file( $file ) ) {
+			if ( in_array( $basename, [ 'ee_cli', 'ee_sites', 'ee_nginx_proxy' ], true ) || ! is_file( $file ) ) {
 				continue;
 			}
 
@@ -227,6 +229,30 @@ class Utils {
 		}
 
 		return $roots;
+	}
+
+	/**
+	 * Return the EasyEngine CLI logs config.
+	 *
+	 * @return string
+	 */
+	private static function get_ee_log_config() {
+
+		$root_dir = rtrim( EE_ROOT_DIR, '/' );
+
+		return <<<LOGROTATE
+{$root_dir}/logs/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    sharedscripts
+}
+LOGROTATE
+		. PHP_EOL;
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -133,7 +133,7 @@ class Utils {
 
 			$contents = @file_get_contents( $file );
 
-			if ( false === $contents || ! self::is_legacy_config( $contents ) ) {
+			if ( false === $contents || ! self::is_legacy_config( $basename, $contents ) ) {
 				continue;
 			}
 
@@ -146,15 +146,84 @@ class Utils {
 	/**
 	 * Check whether a config duplicates EasyEngine log rotation.
 	 *
+	 * @param string $basename Config file basename.
 	 * @param string $contents Config contents.
 	 * @return bool
 	 */
-	private static function is_legacy_config( $contents ) {
+	private static function is_legacy_config( $basename, $contents ) {
 
-		$root_dir = rtrim( EE_ROOT_DIR, '/' );
+		return self::is_legacy_site_config( $basename, $contents )
+			|| self::is_legacy_nginx_proxy_config( $basename, $contents );
+	}
 
-		return false !== strpos( $contents, $root_dir . '/sites/' )
-			|| false !== strpos( $contents, $root_dir . '/services/nginx-proxy/logs/*.log' );
+	/**
+	 * Check whether a config matches old per-site generated configs.
+	 *
+	 * @param string $basename Config file basename.
+	 * @param string $contents Config contents.
+	 * @return bool
+	 */
+	private static function is_legacy_site_config( $basename, $contents ) {
+
+		$site = substr( $basename, 3 );
+
+		if ( ! preg_match( '/^ee_[A-Za-z0-9.-]+$/', $basename ) || false === strpos( $site, '.' ) ) {
+			return false;
+		}
+
+		foreach ( self::get_legacy_roots() as $root_dir ) {
+			$site_path = preg_quote( $root_dir . '/sites/' . $site, '/' );
+
+			if (
+				preg_match( '/' . $site_path . '\/logs\/nginx\/\*\.log/', $contents )
+				&& preg_match( '/' . $site_path . '\/logs\/php\/\*\.log/', $contents )
+				&& false !== strpos( $contents, 'docker inspect -f' )
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether a config matches old nginx-proxy generated config.
+	 *
+	 * @param string $basename Config file basename.
+	 * @param string $contents Config contents.
+	 * @return bool
+	 */
+	private static function is_legacy_nginx_proxy_config( $basename, $contents ) {
+
+		if ( 'ee_nginx_proxy_logrotate' !== $basename ) {
+			return false;
+		}
+
+		foreach ( self::get_legacy_roots() as $root_dir ) {
+			$proxy_path = $root_dir . '/services/nginx-proxy/logs/*.log';
+
+			if ( false !== strpos( $contents, $proxy_path ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Return root paths used by current and legacy EE logrotate configs.
+	 *
+	 * @return array
+	 */
+	private static function get_legacy_roots() {
+
+		$roots = [ rtrim( EE_ROOT_DIR, '/' ) ];
+
+		if ( '/opt/easyengine' !== $roots[0] ) {
+			$roots[] = '/opt/easyengine';
+		}
+
+		return $roots;
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -140,24 +140,29 @@ class Utils {
 	 */
 	private static function validate_configs( array $files ) {
 
-		$command = 'logrotate -d ' . implode( ' ', array_map( 'escapeshellarg', $files ) ) . ' 2>&1';
-		$result  = \EE::launch( $command, false, true );
+		$is_valid = true;
 
-		if ( 0 === $result->return_code ) {
-			\EE::debug( 'EasyEngine logrotate configs validated.' );
-			return true;
+		foreach ( $files as $file ) {
+			$command = 'logrotate -d ' . escapeshellarg( $file ) . ' 2>&1';
+			$result  = \EE::launch( $command, false, true );
+
+			if ( 0 === $result->return_code ) {
+				\EE::debug( 'EasyEngine logrotate config validated: ' . $file );
+				continue;
+			}
+
+			$message = trim( $result->stdout );
+
+			if ( ! self::has_validation_error( $message ) ) {
+				\EE::debug( 'EasyEngine logrotate validation returned a non-zero exit code without errors for ' . $file . ( $message ? '. ' . $message : '' ) );
+				continue;
+			}
+
+			\EE::warning( 'Unable to validate EasyEngine logrotate config: ' . $file . ( $message ? '. ' . $message : '' ) );
+			$is_valid = false;
 		}
 
-		$message = trim( $result->stdout );
-
-		if ( ! self::has_validation_error( $message ) ) {
-			\EE::debug( 'EasyEngine logrotate validation returned a non-zero exit code without errors.' . ( $message ? ' ' . $message : '' ) );
-			return true;
-		}
-
-		\EE::warning( 'Unable to validate EasyEngine logrotate configs.' . ( $message ? ' ' . $message : '' ) );
-
-		return false;
+		return $is_valid;
 	}
 
 	/**
@@ -179,18 +184,23 @@ class Utils {
 	 */
 	private static function force_rotate_configs( array $files ) {
 
-		$command = 'logrotate -f ' . implode( ' ', array_map( 'escapeshellarg', $files ) ) . ' 2>&1';
-		$result  = \EE::launch( $command, false, true );
+		$is_rotated = true;
 
-		if ( 0 === $result->return_code ) {
-			\EE::debug( 'EasyEngine logs force rotated.' );
-			return true;
+		foreach ( $files as $file ) {
+			$command = 'logrotate -f ' . escapeshellarg( $file ) . ' 2>&1';
+			$result  = \EE::launch( $command, false, true );
+
+			if ( 0 === $result->return_code ) {
+				\EE::debug( 'EasyEngine logs force rotated: ' . $file );
+				continue;
+			}
+
+			$message = trim( $result->stdout );
+			\EE::warning( 'Unable to force rotate EasyEngine logs for config: ' . $file . ( $message ? '. ' . $message : '' ) );
+			$is_rotated = false;
 		}
 
-		$message = trim( $result->stdout );
-		\EE::warning( 'Unable to force rotate EasyEngine logs.' . ( $message ? ' ' . $message : '' ) );
-
-		return false;
+		return $is_rotated;
 	}
 
 	/**

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -20,7 +20,7 @@ class Utils {
 		try {
 			self::setup_logrotate_config();
 		} catch ( \Throwable $e ) {
-			\EE::warning( 'Unable to setup EasyEngine logrotate config: ' . $e->getMessage() );
+			\EE::warning( 'Unable to set up EasyEngine logrotate config: ' . $e->getMessage() );
 		}
 	}
 

--- a/php/EE/Logrotate/Utils.php
+++ b/php/EE/Logrotate/Utils.php
@@ -69,7 +69,7 @@ class Utils {
 		\EE::log( 'Installing logrotate.' );
 		$result = \EE::launch( 'DEBIAN_FRONTEND=noninteractive apt-get install -y logrotate', false, true );
 
-		if ( 0 !== $result->return_code || ! self::command_exists( 'logrotate' ) ) {
+		if ( 0 !== $result->return_code ) {
 			\EE::warning( 'Unable to install logrotate. Skipping EasyEngine logrotate setup.' );
 			return false;
 		}

--- a/php/EE/Runner.php
+++ b/php/EE/Runner.php
@@ -174,6 +174,7 @@ class Runner {
 		$rsp->add_step( 'ee-docker-image-migrations', 'EE\Migration\Containers::start_container_migration' );
 		$rsp->add_step( 'ee-update-docker-compose', 'EE\Migration\Containers::update_docker_compose' );
 		$rsp->add_step( 'ee-update-cron-config', 'EE\Cron\Utils\update_cron_config' );
+		$rsp->add_step( 'ee-setup-logrotate', 'EE\Logrotate\Utils::setup_logrotate' );
 
 		return $rsp->execute();
 	}


### PR DESCRIPTION
## Summary

Adds EasyEngine-managed log rotation setup during CLI migration so site, nginx-proxy, and EasyEngine CLI logs do not grow unbounded on Ubuntu/Linux servers.

The migration now writes and validates logrotate configs for:

- `EE_ROOT_DIR/logs/*.log`
- `EE_ROOT_DIR/sites/*/logs/nginx/*.log`
- `EE_ROOT_DIR/sites/*/logs/php/*.log`
- `EE_ROOT_DIR/services/nginx-proxy/logs/*.log`

It also force-rotates these logs once after setup/update, then relies on the system logrotate schedule for daily rotation.

## Details

- Adds `EE\Logrotate\Utils::setup_logrotate()`.
- Registers `ee-setup-logrotate` as the final migration step in `Runner::migrate()`.
- Installs `logrotate` via `apt-get` if missing and available.
- Skips setup on macOS.
- Uses wildcard logrotate patterns so new sites are covered automatically without site-create hooks.
- Uses `copytruncate` to avoid per-site container signaling.
- Keeps 30 daily rotations.
- Validates generated configs with `logrotate -d`.
- Force-runs `logrotate -f` once after successful setup/update.
- Cleans up old generated per-site logrotate configs only after validation succeeds.
- Keeps logrotate failures non-fatal so migrations are not rolled back by optional infrastructure setup.

## Testing

- `php -l php/EE/Logrotate/Utils.php`
- `php -l php/EE/Runner.php`
- `git diff --check origin/develop...HEAD`
- Verified PSR-0 autoload path for `EE\Logrotate\Utils`
- Validated generated logrotate configs in a throwaway Ubuntu 24.04 container with `logrotate -d`
- Verified forced rotation in a throwaway Ubuntu 24.04 container with `logrotate -f`
